### PR TITLE
[Fix] 충돌체 앉은 상태에서만 인식하는 문제

### DIFF
--- a/Assets/Prefabs/Character/Player_V2_Edit.prefab
+++ b/Assets/Prefabs/Character/Player_V2_Edit.prefab
@@ -388,6 +388,7 @@ GameObject:
   - component: {fileID: 2219477002760727318}
   - component: {fileID: 2351764077040386967}
   - component: {fileID: 3524753106698798678}
+  - component: {fileID: 7555502543984381793}
   m_Layer: 6
   m_Name: Player_V2_Edit
   m_TagString: Player
@@ -669,6 +670,28 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: be0b47e8bc9f84e4899fe9133bce1c10, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!64 &7555502543984381793
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5898414512436737983}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &8993977295795288563
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
충돌체 앉은 상태에서만 인식하는 문제

메쉬 콜라이더 적용 후 해결