### PR TITLE
[Fix] Player Mesh 콜라이더 제거, Template Camera 연결, 밝기 관련 버그 수정

### DIFF
--- a/Assets/Prefabs/Character/Player_V2_Edit.prefab
+++ b/Assets/Prefabs/Character/Player_V2_Edit.prefab
@@ -365,7 +365,6 @@ GameObject:
   - component: {fileID: 2219477002760727318}
   - component: {fileID: 2351764077040386967}
   - component: {fileID: 3524753106698798678}
-  - component: {fileID: 7555502543984381793}
   m_Layer: 6
   m_Name: Player_V2_Edit
   m_TagString: Player
@@ -623,28 +622,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: be0b47e8bc9f84e4899fe9133bce1c10, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!64 &7555502543984381793
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5898414512436737983}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 5
-  m_Convex: 1
-  m_CookingOptions: 30
-  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &8993977295795288563
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/SDW/Scenes/[Merge] LevelOneScene(UITest).unity
+++ b/Assets/SDW/Scenes/[Merge] LevelOneScene(UITest).unity
@@ -5195,6 +5195,10 @@ PrefabInstance:
       propertyPath: m_levelSceneName
       value: '[Merge] LevelOneScene(UITest)'
       objectReference: {fileID: 0}
+    - target: {fileID: 2709938355266690523, guid: 3cf0632ef8e261945bc6897b8a583d60, type: 3}
+      propertyPath: m_Camera
+      value: 
+      objectReference: {fileID: 2981407080418281889}
     - target: {fileID: 4742485059466224440, guid: 3cf0632ef8e261945bc6897b8a583d60, type: 3}
       propertyPath: m_levelSceneName
       value: '[Merge] LevelOneScene(UITest)'
@@ -5693,6 +5697,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: cd39ae8f65020e641bebdd57d85591bb, type: 3}
+--- !u!20 &2981407080418281889 stripped
+Camera:
+  m_CorrespondingSourceObject: {fileID: 8826569898667721361, guid: cd39ae8f65020e641bebdd57d85591bb, type: 3}
+  m_PrefabInstance: {fileID: 2981407080418281888}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &5395540165684404076
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/SDW/Scripts/UI/MainMenuUI.cs
+++ b/Assets/SDW/Scripts/UI/MainMenuUI.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -8,12 +9,19 @@ public class MainMenuUI : MonoBehaviour
 {
     [SerializeField] private Button m_exitButton;
 
-    
-    void Start()
+    private void Start()
     {
         m_exitButton.onClick.AddListener(GameManager.Instance.Exit);
-        // Debug.LogError("temp");
         Cursor.lockState = CursorLockMode.None;
-        GameManager.Instance.Graphics.SetBrightness(1f);
+        
+        if (GameManager.Instance.Graphics.IsFirstTime)
+        {
+            GameManager.Instance.Graphics.SetBrightness(1f);
+        }
+    }
+
+    private void OnDisable()
+    {
+        m_exitButton.onClick.RemoveAllListeners();
     }
 }

--- a/Assets/Scenes/[Template] LevelDesign.unity
+++ b/Assets/Scenes/[Template] LevelDesign.unity
@@ -1556,6 +1556,10 @@ PrefabInstance:
       propertyPath: m_levelSceneName
       value: '[Merge] LevelOneScene(UITest)'
       objectReference: {fileID: 0}
+    - target: {fileID: 2709938355266690523, guid: 3cf0632ef8e261945bc6897b8a583d60, type: 3}
+      propertyPath: m_Camera
+      value: 
+      objectReference: {fileID: 2981407080418281889}
     - target: {fileID: 4742485059466224440, guid: 3cf0632ef8e261945bc6897b8a583d60, type: 3}
       propertyPath: m_levelSceneName
       value: '[Merge] LevelOneScene(UITest)'
@@ -1843,6 +1847,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: cd39ae8f65020e641bebdd57d85591bb, type: 3}
+--- !u!20 &2981407080418281889 stripped
+Camera:
+  m_CorrespondingSourceObject: {fileID: 7193743145439110672, guid: cd39ae8f65020e641bebdd57d85591bb, type: 3}
+  m_PrefabInstance: {fileID: 2981407080418281888}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &8702323296657820662 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 2319699047227597326, guid: cd39ae8f65020e641bebdd57d85591bb, type: 3}


### PR DESCRIPTION
* Player에 캡슐 콜라이더와 중복이라 Mesh 콜라이더 제거
* Template의 Canvas와 UI용 Camera 연결
* 게임 화면 -> 타이틀 화면 전환 시 밝아지는 버그 수정